### PR TITLE
Fix required decompression memory usage reported by -vv + --long

### DIFF
--- a/programs/fileio.c
+++ b/programs/fileio.c
@@ -1300,7 +1300,10 @@ FIO_compressZstdFrame(FIO_ctx_t* const fCtx,
         int windowLog;
         UTIL_HumanReadableSize_t windowSize;
         CHECK(ZSTD_CCtx_getParameter(ress.cctx, ZSTD_c_windowLog, &windowLog));
-        if (windowLog == 0) {
+        if (prefs->ldmFlag) {
+            /* If long mode is set libzstd will set this window size internally */
+            windowLog = ZSTD_WINDOWLOG_LIMIT_DEFAULT;
+        } else if (windowLog == 0) {
             const ZSTD_compressionParameters cParams = ZSTD_getCParams(compressionLevel, fileSize, 0);
             windowLog = cParams.windowLog;
         }


### PR DESCRIPTION
The use of --long alters the window size internally in the underlying
library (lib/compress/zstd_compress.c:ZSTD_getCParamsFromCCtxParams),
which changes the memory required for decompression. This means that the
reported requirement from the zstd binary when -vv is specified is
incorrect.

A full fix for this would be to add an API call to be able to retrieve
the required decompression memory from the library, but as a
lighterweight fix we can just take account of the fact we've enabled
long mode and update our verbose output appropriately.

Fixes #2968